### PR TITLE
theme themesDir on exampleSite, use global hugo function, .URL deprecated

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,8 @@
 baseurl = "http://hugo.spf13.com/"
 title = "Hugo Themes"
 author = "Steve Francia"
+theme = "hugo-dgraph-theme"
+themesDir = "../.."
 
 # Number of blogs you want to list on a single page.
 paginate = 5

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <!--[if gt IE 8] <!--> <html class="ie" lang="en"> <!-- ![endif]-->
   <head>
     <meta charset="utf-8">
-      {{ .Hugo.Generator }}
+      {{ hugo.Generator }}
 
     <!-- favicons-->
     <link rel="apple-touch-icon" sizes="57x57" href="assets/images/favicons/apple-touch-icon-57x57.png">
@@ -32,7 +32,7 @@
 
     <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Site.BaseURL }}index.xml">
 
-    {{ if eq .URL "/" }}
+    {{ if eq .Permalink "/" }}
     <title>{{ .Title }}</title>
     <meta property='og:title' content="{{ .Title }}">
     <meta property="og:type" content="website">


### PR DESCRIPTION
is customary to have `theme <name>` and `themesDir <path>` on the exampleSite config file