### PR TITLE
Fixes for broken links in blog preview build

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -12,7 +12,7 @@
 				<a href="{{ .Permalink }}" class="no-hover">
 					<div
 							class="img_square"
-							style="background-image: url({{ $.Site.BaseURL }}images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
+							style="background-image: url({{ $.Site.BaseURL }}/images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
 					</div>
 				</a>
 			</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -310,7 +310,7 @@
         <div class="col-xs-12 offset-xs-0 col-md-10 offset-md-1">
           <img
             class="main__image"
-            src="{{ $.Site.BaseURL }}images/{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}"
+            src="{{ $.Site.BaseURL }}/images/{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}"
           >
           <div class="article-content">{{ .Content }}</div>
           <div class="article-tag-list">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -155,10 +155,10 @@ $(document.links)
 <script src="https://cdnjs.cloudflare.com/ajax/libs/visibility.js/1.2.4/visibility.min.js"></script>
 <link href="https://fonts.googleapis.com/css?family=Indie+Flower" rel="stylesheet">
 <link
-  href='{{ .Site.BaseURL }}css/heart.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/heart.css") }}'
+  href='{{ .Site.BaseURL }}/css/heart.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/heart.css") }}'
   rel="stylesheet">
 <link
-  href='{{ .Site.BaseURL }}css/github-engage.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/github-engage.css") }}'
+  href='{{ .Site.BaseURL }}/css/github-engage.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/github-engage.css") }}'
   rel="stylesheet">
 
 <script

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,24 +4,24 @@
   <meta charset="utf-8">
 
   <!-- favicons-->
-  <link rel="apple-touch-icon" sizes="57x57" href="assets/images/favicons/apple-touch-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="assets/images/favicons/apple-touch-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="assets/images/favicons/apple-touch-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="assets/images/favicons/apple-touch-icon-76x76.png">
+  <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favicons/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favicons/apple-touch-icon-60x60.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favicons/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favicons/apple-touch-icon-76x76.png">
 
-  <link rel="apple-touch-icon" sizes="114x114" href="assets/images/favicons/apple-touch-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="assets/images/favicons/apple-touch-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="assets/images/favicons/apple-touch-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="assets/images/favicons/apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/images/favicons/apple-touch-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favicons/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favicons/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favicons/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favicons/apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicons/apple-touch-icon-180x180.png">
 
-  <link rel="icon" type="image/png" href="assets/images/favicons/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="assets/images/favicons/android-chrome-192x192.png" sizes="192x192">
+  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/assets/images/favicons/android-chrome-192x192.png" sizes="192x192">
   <link rel="icon" type="image/png" href="/assets/favicons/favicon-194x194.png" sizes="194x194">
-  <link rel="icon" type="image/png" href="assets/images/favicons/favicon-96x96.png" sizes="96x96">
-  <link rel="icon" type="image/png" href="assets/images/favicons/favicon-16x16.png" sizes="16x16">
+  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-16x16.png" sizes="16x16">
 
-  <link rel="mask-icon" href="assets/images/favicons/safari-pinned-tab.svg" color="#fe2c06">
+  <link rel="mask-icon" href="/assets/images/favicons/safari-pinned-tab.svg" color="#fe2c06">
   <link rel="shortcut icon" href="/images/favicon.ico">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="msapplication-TileImage" content="/assets/favicons/mstile-144x144.png">
@@ -29,7 +29,7 @@
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
 
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Site.BaseURL }}index.xml">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Site.BaseURL }}/index.xml">
 
   {{ if eq .Permalink "/" }}
     <title>{{ .Title }}</title>
@@ -43,7 +43,7 @@
 
   <meta property="og:url" content="{{ .Permalink }}">
   {{ with .Description }}<meta name="description" content="{{ . }}">{{ end }}
-  {{ with .Params.image }}<meta property="og:image" content="{{ $.Site.BaseURL }}images/{{ . }}">{{ end }}
+  {{ with .Params.image }}<meta property="og:image" content="{{ $.Site.BaseURL }}/images/{{ . }}">{{ end }}
 
   <link href="https://fonts.googleapis.com/css?family=Lato:400,700|Work+Sans:400,500,700,800" rel="stylesheet">
 
@@ -83,22 +83,22 @@
 
   <link
     rel="stylesheet"
-    href='{{ .Site.BaseURL }}css/styles.css?{{ md5 (readFile "/themes/hugo-dgraph-theme/static/css/styles.css") }}'>
+    href='{{ .Site.BaseURL }}/css/styles.css?{{ md5 (readFile "/themes/hugo-dgraph-theme/static/css/styles.css") }}'>
   <link
     rel="stylesheet"
-    href='{{ .Site.BaseURL }}css/custom.css?{{ md5 (readFile "static/css/custom.css") }}'>
+    href='{{ .Site.BaseURL }}/css/custom.css?{{ md5 (readFile "static/css/custom.css") }}'>
 
   <!-- twitter card -->
   {{ if .IsPage }}
     {{ with .Params.image }}
       <meta name="twitter:card" content="summary_large_image"/>
-      <meta name="twitter:image" content="{{ $.Site.BaseURL }}images/{{ . }}"/>
+      <meta name="twitter:image" content="{{ $.Site.BaseURL }}/images/{{ . }}"/>
     {{ else }}
       <meta name="twitter:card" content="summary"/>
     {{ end }}
   {{ else }}
       <meta name="twitter:card" content="summary_large_image"/>
-      <meta name="twitter:image" content="{{ $.Site.BaseURL }}images/diggy-lg.png"/>
+      <meta name="twitter:image" content="{{ $.Site.BaseURL }}/images/diggy-lg.png"/>
   {{ end }}
 
   <meta name="twitter:title" content="{{ .Title }}"/>

--- a/layouts/shortcodes/runnable.html
+++ b/layouts/shortcodes/runnable.html
@@ -94,7 +94,7 @@ public class DgraphMain {
             </div>
           </div>
 
-          <div class="runnable-content runnable-output" style="background: url('{{ .Site.BaseURL }}images/dgraph-black.png'); background-repeat: no-repeat; background-position: center; background-color: #fff;">
+          <div class="runnable-content runnable-output" style="background: url('{{ .Site.BaseURL }}/images/dgraph-black.png'); background-repeat: no-repeat; background-position: center; background-color: #fff;">
             <pre class="output-container empty"><code class="output" tabindex="-1"></code></pre>
           </div>
 


### PR DESCRIPTION
This way when the `BaseURL`  is not passed, the reference links should point to the right place.

Signed-off-by: Prashant Shahi <prashant@dgraph.io>