### PR TITLE
Use absolute paths for link references using BaseURL.

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -12,7 +12,7 @@
 				<a href="{{ .Permalink }}" class="no-hover">
 					<div
 							class="img_square"
-							style="background-image: url({{ $.Site.BaseURL }}/images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
+							style="background-image: url({{ .Site.BaseURL }}/images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
 					</div>
 				</a>
 			</div>

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -12,7 +12,7 @@
 				<a href="{{ .Permalink }}" class="no-hover">
 					<div
 							class="img_square"
-							style="background-image: url(/images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
+							style="background-image: url({{ $.Site.BaseURL }}/images/{{ with .Params.thumbnail }}{{ . }}{{ else }}{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}{{ end }}); {{ with .Params.thumbVerticalPosition }}background-position: 50% {{ . }};{{ end }}">
 					</div>
 				</a>
 			</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -310,7 +310,7 @@
         <div class="col-xs-12 offset-xs-0 col-md-10 offset-md-1">
           <img
             class="main__image"
-            src="/images/{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}"
+            src="{{ $.Site.BaseURL }}/images/{{ with .Params.image }}{{ . }}{{ else }}default.jpg{{ end }}"
           >
           <div class="article-content">{{ .Content }}</div>
           <div class="article-tag-list">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -168,7 +168,7 @@ $(document.links)
 ></script>
 <script
   type="text/javascript"
-  src='/js/custom.js?{{ md5 (readFile "themes/hugo-dgraph-theme/static/js/custom.js") }}'
+  src='{{ .Site.BaseURL }}/js/custom.js?{{ md5 (readFile "themes/hugo-dgraph-theme/static/js/custom.js") }}'
 ></script>
 
 <script src="//unpkg.com/@dgraph-io/community"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -95,9 +95,9 @@
   <!-- / page-footer-->
 </div>
 
-    <script src="/js/clipboard.min.js"></script>
+    <script src="{{ .Site.BaseURL }}/js/clipboard.min.js"></script>
     <script
-      src='/js/runnable.js?{{ md5 (readFile "themes/hugo-dgraph-theme/static/js/runnable.js") }}'
+      src='{{ .Site.BaseURL }}/js/runnable.js?{{ md5 (readFile "themes/hugo-dgraph-theme/static/js/runnable.js") }}'
     ></script>
     <script>
       hljs.initHighlightingOnLoad();
@@ -155,10 +155,10 @@ $(document.links)
 <script src="https://cdnjs.cloudflare.com/ajax/libs/visibility.js/1.2.4/visibility.min.js"></script>
 <link href="https://fonts.googleapis.com/css?family=Indie+Flower" rel="stylesheet">
 <link
-  href='/css/heart.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/heart.css") }}'
+  href='{{ .Site.BaseURL }}/css/heart.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/heart.css") }}'
   rel="stylesheet">
 <link
-  href='/css/github-engage.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/github-engage.css") }}'
+  href='{{ .Site.BaseURL }}/css/github-engage.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/github-engage.css") }}'
   rel="stylesheet">
 
 <script

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
 
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/index.xml">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Site.BaseURL }}/index.xml">
 
   {{ if eq .Permalink "/" }}
     <title>{{ .Title }}</title>
@@ -43,7 +43,7 @@
 
   <meta property="og:url" content="{{ .Permalink }}">
   {{ with .Description }}<meta name="description" content="{{ . }}">{{ end }}
-  {{ with .Params.image }}<meta property="og:image" content="/images/{{ . }}">{{ end }}
+  {{ with .Params.image }}<meta property="og:image" content="{{ $.Site.BaseURL }}/images/{{ . }}">{{ end }}
 
   <link href="https://fonts.googleapis.com/css?family=Lato:400,700|Work+Sans:400,500,700,800" rel="stylesheet">
 
@@ -52,11 +52,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.14.2/highlight.min.js" integrity="sha256-sNPiigbfSkqUzMc5rgrdztLnneCMAp6W9wetJUZu9Zw=" crossorigin="anonymous"></script>
 
   <link
-    href='/css/runnable.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/runnable.css") }}'
+    href='{{ .Site.BaseURL }}/css/runnable.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/runnable.css") }}'
     rel="stylesheet"
   />
   <link
-    href='/css/runnable-custom.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/runnable-custom.css") }}'
+    href='{{ .Site.BaseURL }}/css/runnable-custom.css?{{ md5 (readFile "themes/hugo-dgraph-theme/static/css/runnable-custom.css") }}'
     rel="stylesheet"
   />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
@@ -83,22 +83,22 @@
 
   <link
     rel="stylesheet"
-    href='/css/styles.css?{{ md5 (readFile "/themes/hugo-dgraph-theme/static/css/styles.css") }}'>
+    href='{{ .Site.BaseURL }}/css/styles.css?{{ md5 (readFile "/themes/hugo-dgraph-theme/static/css/styles.css") }}'>
   <link
     rel="stylesheet"
-    href='/css/custom.css?{{ md5 (readFile "static/css/custom.css") }}'>
+    href='{{ .Site.BaseURL }}/css/custom.css?{{ md5 (readFile "static/css/custom.css") }}'>
 
   <!-- twitter card -->
   {{ if .IsPage }}
     {{ with .Params.image }}
       <meta name="twitter:card" content="summary_large_image"/>
-      <meta name="twitter:image" content="/images/{{ . }}"/>
+      <meta name="twitter:image" content="{{ $.Site.BaseURL }}/images/{{ . }}"/>
     {{ else }}
       <meta name="twitter:card" content="summary"/>
     {{ end }}
   {{ else }}
       <meta name="twitter:card" content="summary_large_image"/>
-      <meta name="twitter:image" content="/images/diggy-lg.png"/>
+      <meta name="twitter:image" content="{{ $.Site.BaseURL }}/images/diggy-lg.png"/>
   {{ end }}
 
   <meta name="twitter:title" content="{{ .Title }}"/>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,28 +4,28 @@
   <meta charset="utf-8">
 
   <!-- favicons-->
-  <link rel="apple-touch-icon" sizes="57x57" href="/assets/images/favicons/apple-touch-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/assets/images/favicons/apple-touch-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/assets/images/favicons/apple-touch-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/assets/images/favicons/apple-touch-icon-76x76.png">
+  <link rel="apple-touch-icon" sizes="57x57" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-60x60.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-76x76.png">
 
-  <link rel="apple-touch-icon" sizes="114x114" href="/assets/images/favicons/apple-touch-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/assets/images/favicons/apple-touch-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/assets/images/favicons/apple-touch-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/favicons/apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicons/apple-touch-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.BaseURL }}/assets/images/favicons/apple-touch-icon-180x180.png">
 
-  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/assets/images/favicons/android-chrome-192x192.png" sizes="192x192">
-  <link rel="icon" type="image/png" href="/assets/favicons/favicon-194x194.png" sizes="194x194">
-  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-96x96.png" sizes="96x96">
-  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon-16x16.png" sizes="16x16">
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/images/favicons/android-chrome-192x192.png" sizes="192x192">
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/favicons/favicon-194x194.png" sizes="194x194">
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-16x16.png" sizes="16x16">
 
-  <link rel="mask-icon" href="/assets/images/favicons/safari-pinned-tab.svg" color="#fe2c06">
-  <link rel="shortcut icon" href="/images/favicon.ico">
+  <link rel="mask-icon" href="{{ .Site.BaseURL }}/assets/images/favicons/safari-pinned-tab.svg" color="#fe2c06">
+  <link rel="shortcut icon" href="{{ .Site.BaseURL }}/images/favicon.ico">
   <meta name="msapplication-TileColor" content="#da532c">
-  <meta name="msapplication-TileImage" content="/assets/favicons/mstile-144x144.png">
-  <meta name="msapplication-config" content="/assets/favicons/browserconfig.xml">
+  <meta name="msapplication-TileImage" content="{{ .Site.BaseURL }}/assets/favicons/mstile-144x144.png">
+  <meta name="msapplication-config" content="{{ .Site.BaseURL }}/assets/favicons/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
 
@@ -79,7 +79,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/algoliasearch@3/dist/algoliasearch.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.0.0/dist/instantsearch.production.min.js" integrity="sha256-6S7q0JJs/Kx4kb/fv0oMjS855QTz5Rc2hh9AkIUjUsk=" crossorigin="anonymous"></script>
-  <script src="/js/search.js"></script>
+  <script src="{{ .Site.BaseURL }}/js/search.js"></script>
 
   <link
     rel="stylesheet"

--- a/layouts/partials/page_header.html
+++ b/layouts/partials/page_header.html
@@ -2,7 +2,7 @@
 	<div class="container">
 	  <div class="row">
 		<div class="col-12 offset-0 col-md-10 offset-md-1">
-		  <figure class="page-logo"><a href="/"><img src="/images/logo.svg" alt="Dgraph Logo"></a></figure>
+		  <figure class="page-logo"><a href="/"><img src="{{ .Site.BaseURL }}/images/logo.svg" alt="Dgraph Logo"></a></figure>
 				  {{if .Site.Params.github}}
 			<span class="topnav-stargazers-wrapper">
 			  <a href="https://github.com/{{.Site.Params.github}}" data-show-count="true" aria-label="Star Dgraph on GitHub" class="github-button">Star</a>

--- a/layouts/shortcodes/runnable.html
+++ b/layouts/shortcodes/runnable.html
@@ -94,7 +94,7 @@ public class DgraphMain {
             </div>
           </div>
 
-          <div class="runnable-content runnable-output" style="background: url('/images/dgraph-black.png'); background-repeat: no-repeat; background-position: center; background-color: #fff;">
+          <div class="runnable-content runnable-output" style="background: url('{{ .Site.BaseURL }}/images/dgraph-black.png'); background-repeat: no-repeat; background-position: center; background-color: #fff;">
             <pre class="output-container empty"><code class="output" tabindex="-1"></code></pre>
           </div>
 


### PR DESCRIPTION
This is useful when the theme is used on sites that are hosted in a subfolder instead of the root of the domain.