### PR TITLE
Add discuss topic IDs.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -349,11 +349,11 @@
   <script type="text/javascript">
 DiscourseEmbed = {
   discourseUrl: "{{.Site.Params.discourse}}",
-  {{ if .Params.discuss }}
-  topicId: "{{ .Params.discuss }}"
-  {{ else }}
+  {{ if .Params.discuss -}}
+  topicId: {{ .Params.discuss }}
+  {{ else -}}
   discourseEmbedUrl: "{{ .Permalink }}"
-  {{ end }}
+  {{ end -}}
 };
 (function() {
   var d = document.createElement("script");

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -349,7 +349,11 @@
   <script type="text/javascript">
 DiscourseEmbed = {
   discourseUrl: "{{.Site.Params.discourse}}",
+  {{ if .Params.discuss }}
+  topicId: "{{ .Params.discuss }}"
+  {{ else }}
   discourseEmbedUrl: "{{ .Permalink }}"
+  {{ end }}
 };
 (function() {
   var d = document.createElement("script");


### PR DESCRIPTION
This follows the [Discourse setup](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963) for embedding comments to existing topics.

In a blog post, set the `discuss:` key the topic ID of the blog post discussion from https://discuss.dgraph.io.

If the blog post slug URL or the blog domain happens to change, then this will maintain the same discussion thread for the post. Otherwise, another discussion topic would be created in its place when `discourseEmbedUrl` is different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/hugo-dgraph-theme/15)
<!-- Reviewable:end -->
